### PR TITLE
SSPROD-33102: Pass provider alias in resource

### DIFF
--- a/modules/services/service-principal/main.tf
+++ b/modules/services/service-principal/main.tf
@@ -10,7 +10,7 @@ data "azurerm_subscription" "primary" {
 # Create service principal in customer tenant
 #---------------------------------------------------------------------------------------------
 resource "azuread_service_principal" "sysdig_sp" {
-  client_id = var.sysdig_application_id
+  client_id = var.sysdig_client_id
 }
 
 #---------------------------------------------------------------------------------------------

--- a/modules/services/service-principal/outputs.tf
+++ b/modules/services/service-principal/outputs.tf
@@ -17,6 +17,11 @@ output "service_principal_app_display_name" {
     description = "Display name of the Application created"
 }
 
+output "service_principal_app_id" {
+  value = azuread_service_principal.sysdig_sp.application_id
+  description = "Application ID of the service principal cfreated"
+}
+
 output "service_principal_app_owner_organization_id" {
     value       = azuread_service_principal.sysdig_sp.application_tenant_id
     description = "Organization ID of the Application created"
@@ -25,4 +30,9 @@ output "service_principal_app_owner_organization_id" {
 output "subscription_tenant_id" {
   value       = data.azurerm_subscription.primary.tenant_id
   description = "Tenant ID of the Subscription"
+}
+
+output "subscription_alias" {
+  value = data.azurerm_subscription.primary.display_name
+  description = "Display name of the subscription"
 }

--- a/modules/services/service-principal/outputs.tf
+++ b/modules/services/service-principal/outputs.tf
@@ -17,11 +17,6 @@ output "service_principal_app_display_name" {
     description = "Display name of the Application created"
 }
 
-output "service_principal_app_id" {
-  value = azuread_service_principal.sysdig_sp.application_id
-  description = "Application ID of the service principal cfreated"
-}
-
 output "service_principal_app_owner_organization_id" {
     value       = azuread_service_principal.sysdig_sp.application_tenant_id
     description = "Organization ID of the Application created"

--- a/modules/services/service-principal/variables.tf
+++ b/modules/services/service-principal/variables.tf
@@ -5,5 +5,5 @@ variable "subscription_id" {
 
 variable "sysdig_client_id" {
   type = string
-  description = "Service Application ID in the Sysdig tenant"
+  description = "Service client ID in the Sysdig tenant"
 }

--- a/modules/services/service-principal/variables.tf
+++ b/modules/services/service-principal/variables.tf
@@ -3,7 +3,7 @@ variable "subscription_id" {
   description = "Subscription ID in which to create a trust relationship"
 }
 
-variable "sysdig_application_id" {
+variable "sysdig_client_id" {
   type = string
   description = "Service Application ID in the Sysdig tenant"
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -18,7 +18,7 @@ provider "sysdig" {
 module "project-posture" {
   source                = "../modules/services/service-principal"
   subscription_id       = "db4d1aaa-4d7f-47d8-b0fe-445d0d70ffce"
-  sysdig_application_id = "a39a3795-c3d7-4c8b-9c1a-24ea5011be8a"
+  sysdig_client_id = "a39a3795-c3d7-4c8b-9c1a-24ea5011be8a"
 }
 
 

--- a/test/main.tf
+++ b/test/main.tf
@@ -46,7 +46,7 @@ resource "sysdig_secure_cloud_auth_account" "azure_subscription_test" {
           display_name              = module.project-posture.service_principal_display_name
           id                        = module.project-posture.service_principal_id
           app_display_name          = module.project-posture.service_principal_app_display_name
-          app_id                    = module.project-posture.service_principal_app_id
+          app_id                    = module.project-posture.service_principal_client_id
           app_owner_organization_id = module.project-posture.service_principal_app_owner_organization_id
         }
       }

--- a/test/main.tf
+++ b/test/main.tf
@@ -12,11 +12,11 @@ terraform {
 
 provider "sysdig" {
   sysdig_secure_url       = "https://secure-staging.sysdig.com"
-  sysdig_secure_api_token = "6f9cb282-b956-41a5-b213-eaac199a9881"
+  sysdig_secure_api_token = "<client_secret>"
 }
 
 module "project-posture" {
-  source                = "../modules/service-principal"
+  source                = "../modules/services/service-principal"
   subscription_id       = "db4d1aaa-4d7f-47d8-b0fe-445d0d70ffce"
   sysdig_application_id = "a39a3795-c3d7-4c8b-9c1a-24ea5011be8a"
 }
@@ -27,6 +27,7 @@ resource "sysdig_secure_cloud_auth_account" "azure_subscription_test" {
   provider_id = "test-azure-provider"
   provider_type = "PROVIDER_AZURE"
   provider_tenant_id = module.project-posture.subscription_tenant_id
+  provider_alias = module.project-posture.subscription_alias
 
   feature {
 


### PR DESCRIPTION
This PR is to pass `provider_alias` in the resource so it can be used in the provider for cloud account creation.