### PR TITLE
fix: Ensure event hub namespace uniqueness

### DIFF
--- a/modules/services/event-hub-data-source/main.tf
+++ b/modules/services/event-hub-data-source/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_resource_group" "sysdig_resource_group" {
 # Create an Event Hub Namespace for Sysdig
 #---------------------------------------------------------------------------------------------
 resource "azurerm_eventhub_namespace" "sysdig_event_hub_namespace" {
-  name                = var.event_hub_namespace_name
+  name                = "${var.event_hub_namespace_name}-${var.subscription_id}"
   location            = azurerm_resource_group.sysdig_resource_group.location
   resource_group_name = azurerm_resource_group.sysdig_resource_group.name
   sku                 = var.namespace_sku

--- a/modules/services/event-hub-data-source/variables.tf
+++ b/modules/services/event-hub-data-source/variables.tf
@@ -52,7 +52,7 @@ variable "namespace_sku" {
 variable "event_hub_namespace_name" {
   type        = string
   description = "Name of the Event Hub Namespace to be created"
-  default = "sysdig-event-hub-namespace"
+  default = "sysdig"
 }
 
 variable "event_hub_name" {


### PR DESCRIPTION
Event hub namespace must be unique across Azure, adding subscription id to the name to ensure uniqueness