### PR TITLE
SSPROD-36994: do not try to access root mgmt group in non-org mode

### DIFF
--- a/modules/services/event-hub-data-source/organizational.tf
+++ b/modules/services/event-hub-data-source/organizational.tf
@@ -11,7 +11,7 @@ data "azurerm_management_group" "root_management_group" {
 }
 
 locals {
-  selected_management_group = length(data.azurerm_management_group.onboarded_management_group) > 0 ? values(data.azurerm_management_group.onboarded_management_group) : [data.azurerm_management_group.root_management_group[0]]
+  selected_management_group = var.is_organizational ? (length(data.azurerm_management_group.onboarded_management_group) > 0 ? values(data.azurerm_management_group.onboarded_management_group) : [data.azurerm_management_group.root_management_group[0]]) : []
   all_mg_subscription_ids = flatten([
     for mg in local.selected_management_group : mg.all_subscription_ids
   ])


### PR DESCRIPTION
The change in #27 fixes the onboarding of the organizational mode but introduces a regression when onboarding a single subscription:

```
Error: Invalid index

  on .terraform/modules/single-subscription-threat-detection/modules/services/event-hub-data-source/organizational.tf line 14, in locals:
  14:   selected_management_group = length(data.azurerm_management_group.onboarded_management_group) > 0 ? values(data.azurerm_management_group.onboarded_management_group) : [data.azurerm_management_group.root_management_group[0]]
    ├────────────────
    │ data.azurerm_management_group.root_management_group is empty tuple
```

Avoiding to access the undefined `root_management_group` if `is_organizational` is false fixes the issue.

This was caught by the automated daily regression tests and the fix has been confirmed by testing manually modifying the `source` on `main.tf` to point to my local `terraform-azurerm-secure` repo.