### PR TITLE
use existing resource group and fmt

### DIFF
--- a/modules/services/event-hub-data-source/README.md
+++ b/modules/services/event-hub-data-source/README.md
@@ -69,6 +69,7 @@ No modules.
 | <a name="input_partition_count"></a> [partition\_count](#input\_partition\_count) | The number of partitions in the Event Hub | `number` | `4` | no |
 | <a name="input_region"></a> [region](#input\_region) | Datacenter where Sysdig-related resources will be created | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group to be created | `string` | `"sysdig-resource-group"` | no |
+| <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Name of the existing resource group | `string` | n/a | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Identifier of the subscription to be onboarded | `string` | n/a | yes |
 | <a name="input_sysdig_client_id"></a> [sysdig\_client\_id](#input\_sysdig\_client\_id) | Service client ID in the Sysdig tenant | `string` | n/a | yes |
 | <a name="input_throughput_units"></a> [throughput\_units](#input\_throughput\_units) | The number of throughput units to be allocated to the Event Hub | `number` | `1` | no |

--- a/modules/services/event-hub-data-source/README.md
+++ b/modules/services/event-hub-data-source/README.md
@@ -69,7 +69,7 @@ No modules.
 | <a name="input_partition_count"></a> [partition\_count](#input\_partition\_count) | The number of partitions in the Event Hub | `number` | `4` | no |
 | <a name="input_region"></a> [region](#input\_region) | Datacenter where Sysdig-related resources will be created | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group to be created | `string` | `"sysdig-resource-group"` | no |
-| <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Name of the existing resource group | `string` | n/a | no |
+| <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Name of the existing resource group | `string` | n/a | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Identifier of the subscription to be onboarded | `string` | n/a | yes |
 | <a name="input_sysdig_client_id"></a> [sysdig\_client\_id](#input\_sysdig\_client\_id) | Service client ID in the Sysdig tenant | `string` | n/a | yes |
 | <a name="input_throughput_units"></a> [throughput\_units](#input\_throughput\_units) | The number of throughput units to be allocated to the Event Hub | `number` | `1` | no |

--- a/modules/services/event-hub-data-source/main.tf
+++ b/modules/services/event-hub-data-source/main.tf
@@ -25,7 +25,7 @@ resource "random_string" "random" {
 # Create service principal in customer tenant
 #---------------------------------------------------------------------------------------------
 resource "azuread_service_principal" "sysdig_service_principal" {
-  client_id = var.sysdig_client_id
+  client_id    = var.sysdig_client_id
   use_existing = true
   lifecycle {
     prevent_destroy = true
@@ -33,9 +33,18 @@ resource "azuread_service_principal" "sysdig_service_principal" {
 }
 
 #---------------------------------------------------------------------------------------------
+# Use an existing resource group for Sysdig resources
+#---------------------------------------------------------------------------------------------
+data "azurerm_resource_group" "existing" {
+  count = var.existing_resource_group != null ? 1 : 0
+  name = var.existing_resource_group
+}
+
+#---------------------------------------------------------------------------------------------
 # Create a resource group for Sysdig resources
 #---------------------------------------------------------------------------------------------
 resource "azurerm_resource_group" "sysdig_resource_group" {
+  count    = var.existing_resource_group == null ? 1 : 0
   name     = "${var.resource_group_name}-${local.subscription_hash}"
   location = var.region
 }
@@ -44,12 +53,12 @@ resource "azurerm_resource_group" "sysdig_resource_group" {
 # Create an Event Hub Namespace for Sysdig
 #---------------------------------------------------------------------------------------------
 resource "azurerm_eventhub_namespace" "sysdig_event_hub_namespace" {
-  name                = "${var.event_hub_namespace_name}-${local.subscription_hash}"
-  location            = azurerm_resource_group.sysdig_resource_group.location
-  resource_group_name = azurerm_resource_group.sysdig_resource_group.name
-  sku                 = var.namespace_sku
-  capacity            = var.throughput_units
-  auto_inflate_enabled = var.auto_inflate_enabled
+  name                     = "${var.event_hub_namespace_name}-${local.subscription_hash}"
+  location                 = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].location : azurerm_resource_group.sysdig_resource_group[0].location
+  resource_group_name      = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
+  sku                      = var.namespace_sku
+  capacity                 = var.throughput_units
+  auto_inflate_enabled     = var.auto_inflate_enabled
   maximum_throughput_units = var.maximum_throughput_units
 }
 
@@ -59,7 +68,7 @@ resource "azurerm_eventhub_namespace" "sysdig_event_hub_namespace" {
 resource "azurerm_eventhub" "sysdig_event_hub" {
   name                = "${var.event_hub_name}-${random_string.random.result}"
   namespace_name      = azurerm_eventhub_namespace.sysdig_event_hub_namespace.name
-  resource_group_name = azurerm_resource_group.sysdig_resource_group.name
+  resource_group_name = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
   partition_count     = var.partition_count
   message_retention   = var.message_retention_days
 }
@@ -71,7 +80,7 @@ resource "azurerm_eventhub_consumer_group" "sysdig_consumer_group" {
   name                = var.consumer_group_name
   namespace_name      = azurerm_eventhub_namespace.sysdig_event_hub_namespace.name
   eventhub_name       = azurerm_eventhub.sysdig_event_hub.name
-  resource_group_name = azurerm_resource_group.sysdig_resource_group.name
+  resource_group_name = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
 }
 
 #---------------------------------------------------------------------------------------------
@@ -80,7 +89,7 @@ resource "azurerm_eventhub_consumer_group" "sysdig_consumer_group" {
 resource "azurerm_eventhub_namespace_authorization_rule" "sysdig_rule" {
   name                = var.eventhub_authorization_rule_name
   namespace_name      = azurerm_eventhub_namespace.sysdig_event_hub_namespace.name
-  resource_group_name = azurerm_resource_group.sysdig_resource_group.name
+  resource_group_name = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
 
   listen = true
   send   = true
@@ -121,7 +130,7 @@ resource "azurerm_monitor_diagnostic_setting" "sysdig_diagnostic_setting" {
 resource "azurerm_monitor_aad_diagnostic_setting" "sysdig_entra_diagnostic_setting" {
   count = var.enable_entra ? 1 : 0
 
-  name               = "${var.entra_diagnostic_settings_name}-${local.subscription_hash}"
+  name                           = "${var.entra_diagnostic_settings_name}-${local.subscription_hash}"
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.sysdig_rule.id
   eventhub_name                  = azurerm_eventhub.sysdig_event_hub.name
 
@@ -135,7 +144,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "sysdig_entra_diagnostic_setti
 
   enabled_log {
     category = "SignInLogs"
-    
+
     retention_policy {
       enabled = false
     }
@@ -143,7 +152,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "sysdig_entra_diagnostic_setti
 
   enabled_log {
     category = "NonInteractiveUserSignInLogs"
-  
+
     retention_policy {
       enabled = false
     }
@@ -167,7 +176,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "sysdig_entra_diagnostic_setti
 
   enabled_log {
     category = "ProvisioningLogs"
-  
+
     retention_policy {
       enabled = false
     }
@@ -183,7 +192,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "sysdig_entra_diagnostic_setti
 
   enabled_log {
     category = "RiskyUsers"
-    
+
     retention_policy {
       enabled = false
     }
@@ -191,7 +200,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "sysdig_entra_diagnostic_setti
 
   enabled_log {
     category = "UserRiskEvents"
-    
+
 
     retention_policy {
       enabled = false

--- a/modules/services/event-hub-data-source/main.tf
+++ b/modules/services/event-hub-data-source/main.tf
@@ -36,15 +36,15 @@ resource "azuread_service_principal" "sysdig_service_principal" {
 # Use an existing resource group for Sysdig resources
 #---------------------------------------------------------------------------------------------
 data "azurerm_resource_group" "existing" {
-  count = var.existing_resource_group != null ? 1 : 0
-  name = var.existing_resource_group
+  count = var.resource_group != null ? 1 : 0
+  name = var.resource_group
 }
 
 #---------------------------------------------------------------------------------------------
 # Create a resource group for Sysdig resources
 #---------------------------------------------------------------------------------------------
 resource "azurerm_resource_group" "sysdig_resource_group" {
-  count    = var.existing_resource_group == null ? 1 : 0
+  count    = var.resource_group == null ? 1 : 0
   name     = "${var.resource_group_name}-${local.subscription_hash}"
   location = var.region
 }
@@ -54,8 +54,8 @@ resource "azurerm_resource_group" "sysdig_resource_group" {
 #---------------------------------------------------------------------------------------------
 resource "azurerm_eventhub_namespace" "sysdig_event_hub_namespace" {
   name                     = "${var.event_hub_namespace_name}-${local.subscription_hash}"
-  location                 = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].location : azurerm_resource_group.sysdig_resource_group[0].location
-  resource_group_name      = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
+  location                 = var.resource_group != null ? data.azurerm_resource_group.existing[0].location : azurerm_resource_group.sysdig_resource_group[0].location
+  resource_group_name      = var.resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
   sku                      = var.namespace_sku
   capacity                 = var.throughput_units
   auto_inflate_enabled     = var.auto_inflate_enabled
@@ -68,7 +68,7 @@ resource "azurerm_eventhub_namespace" "sysdig_event_hub_namespace" {
 resource "azurerm_eventhub" "sysdig_event_hub" {
   name                = "${var.event_hub_name}-${random_string.random.result}"
   namespace_name      = azurerm_eventhub_namespace.sysdig_event_hub_namespace.name
-  resource_group_name = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
+  resource_group_name = var.resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
   partition_count     = var.partition_count
   message_retention   = var.message_retention_days
 }
@@ -80,7 +80,7 @@ resource "azurerm_eventhub_consumer_group" "sysdig_consumer_group" {
   name                = var.consumer_group_name
   namespace_name      = azurerm_eventhub_namespace.sysdig_event_hub_namespace.name
   eventhub_name       = azurerm_eventhub.sysdig_event_hub.name
-  resource_group_name = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
+  resource_group_name = var.resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
 }
 
 #---------------------------------------------------------------------------------------------
@@ -89,7 +89,7 @@ resource "azurerm_eventhub_consumer_group" "sysdig_consumer_group" {
 resource "azurerm_eventhub_namespace_authorization_rule" "sysdig_rule" {
   name                = var.eventhub_authorization_rule_name
   namespace_name      = azurerm_eventhub_namespace.sysdig_event_hub_namespace.name
-  resource_group_name = var.existing_resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
+  resource_group_name = var.resource_group != null ? data.azurerm_resource_group.existing[0].name : azurerm_resource_group.sysdig_resource_group[0].name
 
   listen = true
   send   = true

--- a/modules/services/event-hub-data-source/organizational.tf
+++ b/modules/services/event-hub-data-source/organizational.tf
@@ -6,7 +6,7 @@ data "azurerm_management_group" "onboarded_management_group" {
 }
 
 data "azurerm_management_group" "root_management_group" {
-  count  = var.is_organizational && length(var.management_group_ids) == 0 ? 1 : 0
+  count        = var.is_organizational && length(var.management_group_ids) == 0 ? 1 : 0
   display_name = "Tenant Root Group"
 }
 
@@ -18,12 +18,12 @@ locals {
 }
 
 data "azurerm_subscription" "onboarded_subscriptions" {
-  for_each = var.is_organizational && length(local.all_mg_subscription_ids) > 0 ? toset(local.all_mg_subscription_ids) : toset([])
+  for_each        = var.is_organizational && length(local.all_mg_subscription_ids) > 0 ? toset(local.all_mg_subscription_ids) : toset([])
   subscription_id = each.value
 }
 
-locals { 
-    enabled_subscriptions = var.is_organizational ? [for s in data.azurerm_subscription.onboarded_subscriptions : s if s.state == "Enabled"] : []
+locals {
+  enabled_subscriptions = var.is_organizational ? [for s in data.azurerm_subscription.onboarded_subscriptions : s if s.state == "Enabled"] : []
 }
 
 #---------------------------------------------------------------------------------------------
@@ -32,8 +32,8 @@ locals {
 resource "azurerm_monitor_diagnostic_setting" "sysdig_org_diagnostic_setting" {
   count = var.is_organizational ? length(local.enabled_subscriptions) : 0
 
-  name               = "${var.diagnostic_settings_name}-${local.subscription_hash}"
-  target_resource_id = local.enabled_subscriptions[count.index].id
+  name                           = "${var.diagnostic_settings_name}-${local.subscription_hash}"
+  target_resource_id             = local.enabled_subscriptions[count.index].id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.sysdig_rule.id
   eventhub_name                  = azurerm_eventhub.sysdig_event_hub.name
 

--- a/modules/services/event-hub-data-source/outputs.tf
+++ b/modules/services/event-hub-data-source/outputs.tf
@@ -8,11 +8,11 @@ output "event_hub_namespace" {
   description = "Name of the newly created Event Hub Namespace"
 }
 output "consumer_group_name" {
-    value       = azurerm_eventhub_consumer_group.sysdig_consumer_group.name
-    description = "Name of the newly created Event Hub Consumer Group"
+  value       = azurerm_eventhub_consumer_group.sysdig_consumer_group.name
+  description = "Name of the newly created Event Hub Consumer Group"
 }
 
 output "subscription_alias" {
-  value = data.azurerm_subscription.sysdig_subscription.display_name
+  value       = data.azurerm_subscription.sysdig_subscription.display_name
   description = "Display name of the subscription"
 }

--- a/modules/services/event-hub-data-source/variables.tf
+++ b/modules/services/event-hub-data-source/variables.tf
@@ -66,7 +66,7 @@ variable "resource_group_name" {
   default     = "sysdig-resource-group"
 }
 
-variable "existing_resource_group" {
+variable "resource_group" {
   type        = string
   description = "Name of the existing resource group"
   default     = null

--- a/modules/services/event-hub-data-source/variables.tf
+++ b/modules/services/event-hub-data-source/variables.tf
@@ -4,7 +4,7 @@ variable "subscription_id" {
 }
 
 variable "sysdig_client_id" {
-  type = string
+  type        = string
   description = "Service client ID in the Sysdig tenant"
 }
 
@@ -61,33 +61,39 @@ variable "event_hub_name" {
 }
 
 variable "resource_group_name" {
-  type = string
+  type        = string
   description = "Name of the resource group to be created"
-  default = "sysdig-resource-group"
+  default     = "sysdig-resource-group"
+}
+
+variable "existing_resource_group" {
+  type        = string
+  description = "Name of the existing resource group"
+  default     = null
 }
 
 variable "consumer_group_name" {
-  type = string
+  type        = string
   description = "Name of the consumer group to be created"
-  default = "sysdig-consumer-group" 
+  default     = "sysdig-consumer-group"
 }
 
 variable "eventhub_authorization_rule_name" {
-  type = string
+  type        = string
   description = "Name of the authorization rule to be created"
-  default = "sysdig-send-listen-rule"
+  default     = "sysdig-send-listen-rule"
 }
 
 variable "diagnostic_settings_name" {
-  type = string
+  type        = string
   description = "Name of the diagnostic settings to be created"
-  default = "sysdig-diagnostic-settings"
+  default     = "sysdig-diagnostic-settings"
 }
 
 variable "entra_diagnostic_settings_name" {
-  type = string
+  type        = string
   description = "Name of the Entra diagnostic settings to be created"
-  default = "sysdig-entra-diagnostic-settings"
+  default     = "sysdig-entra-diagnostic-settings"
 }
 
 variable "is_organizational" {

--- a/modules/services/host-scanner/main.tf
+++ b/modules/services/host-scanner/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  features { }
+  features {}
 }
 
 data "azurerm_subscription" "primary" {
@@ -20,7 +20,7 @@ resource "azurerm_lighthouse_definition" "lighthouse_definition" {
 }
 
 resource "azurerm_lighthouse_assignment" "lighthouse_assignment" {
-  count = var.is_organizational ? 0 : 1
+  count                    = var.is_organizational ? 0 : 1
   scope                    = "/subscriptions/${var.subscription_id}"
   lighthouse_definition_id = azurerm_lighthouse_definition.lighthouse_definition.id
 }

--- a/modules/services/host-scanner/organizational.tf
+++ b/modules/services/host-scanner/organizational.tf
@@ -3,18 +3,18 @@
 #---------------------------------------------------------------------------------------------
 # If no management group is present, then the root management group is used to onboard all the subscriptions
 data "azurerm_management_group" "root_management_group" {
-  count  = var.is_organizational && length(var.management_group_ids) == 0 ? 1 : 0
+  count        = var.is_organizational && length(var.management_group_ids) == 0 ? 1 : 0
   display_name = "Tenant Root Group"
 }
 
 data "azurerm_management_group" "management_groups" {
   for_each = var.is_organizational && length(var.management_group_ids) > 0 ? var.management_group_ids : []
-  name = each.value
+  name     = each.value
 }
 
 locals {
   subscriptions = toset(var.is_organizational && length(var.management_group_ids) == 0 ? data.azurerm_management_group.root_management_group[0].subscription_ids :
-    flatten([for m in data.azurerm_management_group.management_groups : m.subscription_ids]))
+  flatten([for m in data.azurerm_management_group.management_groups : m.subscription_ids]))
 }
 
 resource "azurerm_lighthouse_assignment" "lighthouse_assignment_for_tenant" {

--- a/modules/services/host-scanner/output.tf
+++ b/modules/services/host-scanner/output.tf
@@ -4,6 +4,6 @@ output "lighthouse_definition_display_id" {
 }
 
 output "subscription_alias" {
-  value = data.azurerm_subscription.primary.display_name
+  value       = data.azurerm_subscription.primary.display_name
   description = "Display name of the subscription"
 }

--- a/modules/services/host-scanner/variables.tf
+++ b/modules/services/host-scanner/variables.tf
@@ -1,15 +1,15 @@
 variable "subscription_id" {
-  type = string
+  type        = string
   description = "Subscription ID in which to create a trust relationship"
 }
 
 variable "sysdig_tenant_id" {
-  type = string
+  type        = string
   description = "Sysdig Tenant ID"
 }
 
 variable "sysdig_service_principal_id" {
-  type = string
+  type        = string
   description = "Service Principal ID in the Sysdig tenant"
 }
 

--- a/modules/services/service-principal/main.tf
+++ b/modules/services/service-principal/main.tf
@@ -65,7 +65,7 @@ resource "azurerm_role_definition" "sysdig_cspm_role" {
 # Custom role assignment for collecting authsettings
 #---------------------------------------------------------------------------------------------
 resource "azurerm_role_assignment" "sysdig_cspm_role_assignment" {
-  scope                = data.azurerm_subscription.primary.id
-  role_definition_id   = azurerm_role_definition.sysdig_cspm_role.role_definition_resource_id
-  principal_id         = azuread_service_principal.sysdig_sp.object_id
+  scope              = data.azurerm_subscription.primary.id
+  role_definition_id = azurerm_role_definition.sysdig_cspm_role.role_definition_resource_id
+  principal_id       = azuread_service_principal.sysdig_sp.object_id
 }

--- a/modules/services/service-principal/organizational.tf
+++ b/modules/services/service-principal/organizational.tf
@@ -2,14 +2,14 @@
 # Fetch the management groups for customer tenant and onboard subscriptions under them
 #---------------------------------------------------------------------------------------------
 data "azurerm_management_group" "root_management_group" {
-  count  = var.is_organizational && length(var.management_group_ids) == 0 ? 1 : 0
+  count        = var.is_organizational && length(var.management_group_ids) == 0 ? 1 : 0
   display_name = "Tenant Root Group"
 }
 
 locals {
   # when empty, this will be the root management group whose default display name is "Tenant root group"
   management_groups = var.is_organizational && length(var.management_group_ids) == 0 ? [data.azurerm_management_group.root_management_group[0].id] : toset(
-    [for m in var.management_group_ids : format("%s/%s", "/providers/Microsoft.Management/managementGroups",m)])
+  [for m in var.management_group_ids : format("%s/%s", "/providers/Microsoft.Management/managementGroups", m)])
 }
 
 #---------------------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ resource "azurerm_role_definition" "sysdig_cspm_role_for_tenant" {
   description = "Custom role for collecting Authsettings for CIS Benchmark"
 
   permissions {
-    actions     = [
+    actions = [
       "Microsoft.Web/sites/config/list/action"
     ]
     not_actions = []
@@ -51,7 +51,7 @@ resource "azurerm_role_definition" "sysdig_cspm_role_for_tenant" {
 resource "azurerm_role_assignment" "sysdig_cspm_role_assignment_for_tenant" {
   for_each = var.is_organizational ? local.management_groups : []
 
-  scope                = each.key
-  role_definition_id   = azurerm_role_definition.sysdig_cspm_role_for_tenant[each.key].role_definition_resource_id
-  principal_id         = azuread_service_principal.sysdig_sp.object_id
+  scope              = each.key
+  role_definition_id = azurerm_role_definition.sysdig_cspm_role_for_tenant[each.key].role_definition_resource_id
+  principal_id       = azuread_service_principal.sysdig_sp.object_id
 }

--- a/modules/services/service-principal/outputs.tf
+++ b/modules/services/service-principal/outputs.tf
@@ -8,18 +8,18 @@ output "service_principal_client_id" {
   description = "Client ID of the Service Principal created"
 }
 output "service_principal_id" {
-    value       = azuread_service_principal.sysdig_sp.id
-    description = "Service Principal ID on the customer tenant"
+  value       = azuread_service_principal.sysdig_sp.id
+  description = "Service Principal ID on the customer tenant"
 }
 
 output "service_principal_app_display_name" {
-    value       = azuread_service_principal.sysdig_sp.display_name
-    description = "Display name of the Application created"
+  value       = azuread_service_principal.sysdig_sp.display_name
+  description = "Display name of the Application created"
 }
 
 output "service_principal_app_owner_organization_id" {
-    value       = azuread_service_principal.sysdig_sp.application_tenant_id
-    description = "Organization ID of the Application created"
+  value       = azuread_service_principal.sysdig_sp.application_tenant_id
+  description = "Organization ID of the Application created"
 }
 
 output "subscription_tenant_id" {
@@ -28,6 +28,6 @@ output "subscription_tenant_id" {
 }
 
 output "subscription_alias" {
-  value = data.azurerm_subscription.primary.display_name
+  value       = data.azurerm_subscription.primary.display_name
   description = "Display name of the subscription"
 }

--- a/modules/services/service-principal/variables.tf
+++ b/modules/services/service-principal/variables.tf
@@ -1,10 +1,10 @@
 variable "subscription_id" {
-  type = string
+  type        = string
   description = "Subscription ID in which to create a trust relationship"
 }
 
 variable "sysdig_client_id" {
-  type = string
+  type        = string
   description = "Service client ID in the Sysdig tenant"
 }
 

--- a/modules/services/service-principal/versions.tf
+++ b/modules/services/service-principal/versions.tf
@@ -3,12 +3,12 @@ terraform {
 
   required_providers {
     azurerm = {
-        source  = "hashicorp/azurerm"
-        version = ">= 3.76.0"
+      source  = "hashicorp/azurerm"
+      version = ">= 3.76.0"
     }
     azuread = {
-        source  = "hashicorp/azuread"
-        version = ">= 2.43.0"
+      source  = "hashicorp/azuread"
+      version = ">= 2.43.0"
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"

--- a/test/organization/main.tf
+++ b/test/organization/main.tf
@@ -4,7 +4,7 @@ provider "azurerm" {
 terraform {
   required_providers {
     sysdig = {
-      source = "local/sysdiglabs/sysdig"
+      source  = "local/sysdiglabs/sysdig"
       version = "~> 1.0.0"
     }
   }
@@ -16,19 +16,19 @@ provider "sysdig" {
 }
 
 module "organization-posture" {
-  source                = "../modules/services/service-principal"
-  subscription_id       = "test-azure-provider"
-  sysdig_client_id      = "<sysdig_application_client_id>"
-  is_organizational     = true
-  management_group_ids  = ["mgmt-group-id1", "mgmt-group-id2"] // if not provided, takes root management group by default
+  source               = "../modules/services/service-principal"
+  subscription_id      = "test-azure-provider"
+  sysdig_client_id     = "<sysdig_application_client_id>"
+  is_organizational    = true
+  management_group_ids = ["mgmt-group-id1", "mgmt-group-id2"] // if not provided, takes root management group by default
 }
 
 resource "sysdig_secure_cloud_auth_account" "azure_subscription_test" {
-  enabled = true
-  provider_id = "test-azure-provider"
-  provider_type = "PROVIDER_AZURE"
+  enabled            = true
+  provider_id        = "test-azure-provider"
+  provider_type      = "PROVIDER_AZURE"
   provider_tenant_id = module.organization-posture.subscription_tenant_id
-  provider_alias = module.organization-posture.subscription_alias
+  provider_alias     = module.organization-posture.subscription_alias
 
   feature {
 

--- a/test/single_subscription/main.tf
+++ b/test/single_subscription/main.tf
@@ -4,7 +4,7 @@ provider "azurerm" {
 terraform {
   required_providers {
     sysdig = {
-      source = "local/sysdiglabs/sysdig"
+      source  = "local/sysdiglabs/sysdig"
       version = "~> 1.0.0"
     }
   }
@@ -16,18 +16,18 @@ provider "sysdig" {
 }
 
 module "subscription-posture" {
-  source                = "../modules/services/service-principal"
-  subscription_id       = "test-azure-provider"
-  sysdig_client_id      = "<sysdig_application_client_id>"
+  source           = "../modules/services/service-principal"
+  subscription_id  = "test-azure-provider"
+  sysdig_client_id = "<sysdig_application_client_id>"
 }
 
 
 resource "sysdig_secure_cloud_auth_account" "azure_subscription_test" {
-  enabled = true
-  provider_id = "test-azure-provider"
-  provider_type = "PROVIDER_AZURE"
+  enabled            = true
+  provider_id        = "test-azure-provider"
+  provider_type      = "PROVIDER_AZURE"
   provider_tenant_id = module.subscription-posture.subscription_tenant_id
-  provider_alias = module.subscription-posture.subscription_alias
+  provider_alias     = module.subscription-posture.subscription_alias
 
   feature {
 


### PR DESCRIPTION
Add the ability to pass an existing Azure resource group. Default behavior is still to create a new one.
Ran a terraform fmt recursively.