### PR TITLE
Move explicit depends_on to feature resource

### DIFF
--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -44,11 +44,4 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_service_principal" 
       }
     }
   })
-
-  depends_on = [
-    azurerm_lighthouse_assignment.lighthouse_assignment,
-
-    # conditional based on org onboarding
-    azurerm_lighthouse_assignment.lighthouse_assignment_for_tenant
-  ]
 }

--- a/modules/config-posture/main.tf
+++ b/modules/config-posture/main.tf
@@ -98,5 +98,4 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_service_principal" 
       }
     }
   })
-
 }

--- a/modules/config-posture/main.tf
+++ b/modules/config-posture/main.tf
@@ -99,13 +99,4 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_service_principal" 
     }
   })
 
-  depends_on = [
-    azuread_directory_role_assignment.sysdig_ad_reader,
-    azurerm_role_assignment.sysdig_reader,
-    azurerm_role_assignment.sysdig_cspm_role_assignment,
-
-    # conditional based on org onboarding
-    azurerm_role_assignment.sysdig_reader_for_tenant,
-    azurerm_role_assignment.sysdig_cspm_role_assignment_for_tenant
-  ]
 }

--- a/modules/integrations/event-hub/main.tf
+++ b/modules/integrations/event-hub/main.tf
@@ -286,15 +286,4 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_event_hub" {
       }
     }
   })
-
-  depends_on = [
-    azurerm_role_assignment.sysdig_data_receiver,
-    azurerm_monitor_diagnostic_setting.sysdig_diagnostic_setting,
-
-    # conditional based on if entra enabled
-    azurerm_monitor_aad_diagnostic_setting.sysdig_entra_diagnostic_setting,
-
-    # conditional based on org onboarding
-    azurerm_monitor_diagnostic_setting.sysdig_org_diagnostic_setting
-  ]
 }

--- a/test/examples/modular_organization/agentless_scanning.tf
+++ b/test/examples/modular_organization/agentless_scanning.tf
@@ -16,4 +16,5 @@ resource "sysdig_secure_cloud_auth_account_feature" "agentless_scanning" {
   type       = "FEATURE_SECURE_AGENTLESS_SCANNING"
   enabled    = true
   components = [module.agentless-scanning.service_principal_component_id]
+  depends_on = [ module.agentless-scanning ]
 }

--- a/test/examples/modular_organization/event_hub.tf
+++ b/test/examples/modular_organization/event_hub.tf
@@ -17,4 +17,5 @@ resource "sysdig_secure_cloud_auth_account_feature" "threat_detection" {
   type       = "FEATURE_SECURE_THREAT_DETECTION"
   enabled    = true
   components = [module.event-hub.event_hub_component_id]
+  depends_on = [ module.event-hub ]
 }

--- a/test/examples/modular_organization/onboarding_with_posture.tf
+++ b/test/examples/modular_organization/onboarding_with_posture.tf
@@ -43,4 +43,5 @@ resource "sysdig_secure_cloud_auth_account_feature" "config_posture" {
   type       = "FEATURE_SECURE_CONFIG_POSTURE"
   enabled    = true
   components = [module.config-posture.service_principal_component_id]
+  depends_on = [ module.config-posture ]
 }

--- a/test/examples/modular_single_subscription/agentless_scanning.tf
+++ b/test/examples/modular_single_subscription/agentless_scanning.tf
@@ -14,4 +14,5 @@ resource "sysdig_secure_cloud_auth_account_feature" "agentless_scanning" {
   type       = "FEATURE_SECURE_AGENTLESS_SCANNING"
   enabled    = true
   components = [module.agentless-scanning.service_principal_component_id]
+  depends_on = [ module.agentless-scanning ]
 }

--- a/test/examples/modular_single_subscription/event_hub.tf
+++ b/test/examples/modular_single_subscription/event_hub.tf
@@ -15,4 +15,5 @@ resource "sysdig_secure_cloud_auth_account_feature" "threat_detection" {
   type       = "FEATURE_SECURE_THREAT_DETECTION"
   enabled    = true
   components = [module.event-hub.event_hub_component_id]
+  depends_on = [ module.event-hub ]
 }

--- a/test/examples/modular_single_subscription/onboarding_with_posture.tf
+++ b/test/examples/modular_single_subscription/onboarding_with_posture.tf
@@ -39,4 +39,5 @@ resource "sysdig_secure_cloud_auth_account_feature" "config_posture" {
   type       = "FEATURE_SECURE_CONFIG_POSTURE"
   enabled    = true
   components = [module.config-posture.service_principal_component_id]
+  depends_on = [ module.config-posture ]
 }


### PR DESCRIPTION
Change summary:
--------------------
- Removing explicit depends_on enumeration within each sub module
- Adding explicit depends_on at module level to the feature resource (added this in test snippets)
   Verified using `terraform graph` the feature resource dependency waiting on entire module to be completed first.