### PR TITLE
fix(event-hub): avoid creation of ds for single sub when organizational (Internal)

### DIFF
--- a/modules/integrations/event-hub/main.tf
+++ b/modules/integrations/event-hub/main.tf
@@ -120,6 +120,8 @@ resource "azurerm_role_assignment" "sysdig_data_receiver" {
 # Create diagnostic settings for the subscription
 #---------------------------------------------------------------------------------------------
 resource "azurerm_monitor_diagnostic_setting" "sysdig_diagnostic_setting" {
+  count = var.is_organizational ? 0 : 1 
+  
   name                           = "${var.diagnostic_settings_name}-${random_string.random.result}-${local.subscription_hash}"
   target_resource_id             = data.azurerm_subscription.sysdig_subscription.id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.sysdig_rule.id

--- a/modules/services/event-hub-data-source/main.tf
+++ b/modules/services/event-hub-data-source/main.tf
@@ -109,6 +109,8 @@ resource "azurerm_role_assignment" "sysdig_data_receiver" {
 # Create diagnostic settings for the subscription
 #---------------------------------------------------------------------------------------------
 resource "azurerm_monitor_diagnostic_setting" "sysdig_diagnostic_setting" {
+  count = var.is_organizational ? 0 : 1 
+
   name                           = "${var.diagnostic_settings_name}-${local.subscription_hash}"
   target_resource_id             = data.azurerm_subscription.sysdig_subscription.id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.sysdig_rule.id


### PR DESCRIPTION
Don't create single subscription diagnostic settings if the is_organizational flag is true