### PR TITLE
Use all_subscription_ids flags instead of subscription_ids for azure onboarding.

### DIFF
--- a/modules/agentless-scanning/organizational.tf
+++ b/modules/agentless-scanning/organizational.tf
@@ -13,8 +13,8 @@ data "azurerm_management_group" "management_groups" {
 }
 
 locals {
-  subscriptions = toset(var.is_organizational && length(var.management_group_ids) == 0 ? data.azurerm_management_group.root_management_group[0].subscription_ids :
-  flatten([for m in data.azurerm_management_group.management_groups : m.subscription_ids]))
+  subscriptions = toset(var.is_organizational && length(var.management_group_ids) == 0 ? data.azurerm_management_group.root_management_group[0].all_subscription_ids :
+  flatten([for m in data.azurerm_management_group.management_groups : m.all_subscription_ids]))
 }
 
 resource "azurerm_lighthouse_assignment" "lighthouse_assignment_for_tenant" {


### PR DESCRIPTION
The subscription_ids variable for a management group is unreliable while the all_subscription_ids is always populated.

This was leading santa lucia not be able to properly onboard agentless scanning.