### PR TITLE
Remove provider stanzas from submodules

### DIFF
--- a/modules/onboarding/main.tf
+++ b/modules/onboarding/main.tf
@@ -1,7 +1,3 @@
-provider "azurerm" {
-  features {}
-}
-
 data "azurerm_subscription" "primary" {
   subscription_id = var.subscription_id
 }

--- a/modules/services/host-scanner/main.tf
+++ b/modules/services/host-scanner/main.tf
@@ -1,7 +1,3 @@
-provider "azurerm" {
-  features {}
-}
-
 data "azurerm_subscription" "primary" {
   subscription_id = var.subscription_id
 }

--- a/modules/services/service-principal/main.tf
+++ b/modules/services/service-principal/main.tf
@@ -1,7 +1,3 @@
-provider "azurerm" {
-  features {}
-}
-
 data "azurerm_subscription" "primary" {
   subscription_id = var.subscription_id
 }


### PR DESCRIPTION
Submodules should not redefine `provider` stanzas that are defined in the top level main.tf. The `sysdig` and `azuread` providers are already handled this way, so `azurerm` should be safe to remove as well, and lets us update to 4.x of the `azurerm` provider (as `subscription_id` is already in all main.tf's provided) 