### PR TITLE
Ensure diagnostic settings are created correctly in organization installs

### DIFF
--- a/modules/integrations/event-hub/main.tf
+++ b/modules/integrations/event-hub/main.tf
@@ -121,7 +121,7 @@ resource "azurerm_role_assignment" "sysdig_data_receiver" {
 # Create diagnostic settings for the subscription
 #---------------------------------------------------------------------------------------------
 resource "azurerm_monitor_diagnostic_setting" "sysdig_diagnostic_setting" {
-  count = length(var.enabled_platform_logs) > 0 ? 1 : 0
+  count = length(var.enabled_platform_logs) > 0 && !var.is_organizational ? 1 : 0
 
   name                           = "${var.diagnostic_settings_name}-${random_string.random.result}-${local.subscription_hash}"
   target_resource_id             = data.azurerm_subscription.sysdig_subscription.id

--- a/modules/integrations/event-hub/organizational.tf
+++ b/modules/integrations/event-hub/organizational.tf
@@ -32,7 +32,7 @@ locals {
 resource "azurerm_monitor_diagnostic_setting" "sysdig_org_diagnostic_setting" {
   count = var.is_organizational ? length(local.enabled_subscriptions) : 0
 
-  name                           = "${var.diagnostic_settings_name}-${local.subscription_hash}"
+  name                           = "${var.diagnostic_settings_name}-${substr(md5(local.enabled_subscriptions[count.index].id), 0, 8)}"
   target_resource_id             = local.enabled_subscriptions[count.index].id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.sysdig_rule.id
   eventhub_name                  = azurerm_eventhub.sysdig_event_hub.name


### PR DESCRIPTION
When doing an org install, a diagnostic setting is created on the management subscription [here](https://github.com/sysdiglabs/terraform-azurerm-secure/blob/main/modules/integrations/event-hub/main.tf#L123), and then again in the loop [here](https://github.com/sysdiglabs/terraform-azurerm-secure/blob/main/modules/integrations/event-hub/organizational.tf#L33). These conflict and cause an error, and [this line](https://github.com/sysdiglabs/terraform-azurerm-secure/blob/main/modules/integrations/event-hub/main.tf#L124) needs to check for var.is_organizational

When looping through all subscriptions creating the diagnostic settings, we use the [same name for each](https://github.com/sysdiglabs/terraform-azurerm-secure/blob/main/modules/integrations/event-hub/organizational.tf#L35). This needs to be dynamic based on the subscription in the for_each loop