### PR TITLE
Update modules for azuread 3.0.1

### DIFF
--- a/modules/config-posture/main.tf
+++ b/modules/config-posture/main.tf
@@ -92,7 +92,7 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_service_principal" 
       active_directory_service_principal = {
         account_enabled           = true
         display_name              = azuread_service_principal.sysdig_cspm_sp.display_name
-        id                        = azuread_service_principal.sysdig_cspm_sp.id
+        id                        = azuread_service_principal.sysdig_cspm_sp.object_id
         app_display_name          = azuread_service_principal.sysdig_cspm_sp.display_name
         app_id                    = azuread_service_principal.sysdig_cspm_sp.client_id
         app_owner_organization_id = azuread_service_principal.sysdig_cspm_sp.application_tenant_id

--- a/modules/integrations/event-hub/main.tf
+++ b/modules/integrations/event-hub/main.tf
@@ -176,7 +176,7 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_event_hub" {
         active_directory_service_principal = {
           account_enabled           = true
           display_name              = azuread_service_principal.sysdig_event_hub_sp.display_name
-          id                        = azuread_service_principal.sysdig_event_hub_sp.id
+          id                        = azuread_service_principal.sysdig_event_hub_sp.object_id
           app_display_name          = azuread_service_principal.sysdig_event_hub_sp.display_name
           app_id                    = azuread_service_principal.sysdig_event_hub_sp.client_id
           app_owner_organization_id = azuread_service_principal.sysdig_event_hub_sp.application_tenant_id

--- a/modules/onboarding/main.tf
+++ b/modules/onboarding/main.tf
@@ -52,7 +52,7 @@ resource "sysdig_secure_cloud_auth_account" "azure_account" {
         active_directory_service_principal = {
           account_enabled           = true
           display_name              = azuread_service_principal.sysdig_onboarding_sp.display_name
-          id                        = azuread_service_principal.sysdig_onboarding_sp.id
+          id                        = azuread_service_principal.sysdig_onboarding_sp.object_id
           app_display_name          = azuread_service_principal.sysdig_onboarding_sp.display_name
           app_id                    = azuread_service_principal.sysdig_onboarding_sp.client_id
           app_owner_organization_id = azuread_service_principal.sysdig_onboarding_sp.application_tenant_id

--- a/modules/services/service-principal/outputs.tf
+++ b/modules/services/service-principal/outputs.tf
@@ -8,7 +8,7 @@ output "service_principal_client_id" {
   description = "Client ID of the Service Principal created"
 }
 output "service_principal_id" {
-  value       = azuread_service_principal.sysdig_sp.id
+  value       = azuread_service_principal.sysdig_sp.object_id
   description = "Service Principal ID on the customer tenant"
 }
 

--- a/modules/vm-workload-scanning/main.tf
+++ b/modules/vm-workload-scanning/main.tf
@@ -116,7 +116,7 @@ resource "sysdig_secure_cloud_auth_account_component" "azure_workload_scanning_c
       active_directory_service_principal = {
         account_enabled           = true
         display_name              = azuread_service_principal.sysdig_vm_workload_scanning_sp.display_name
-        id                        = azuread_service_principal.sysdig_vm_workload_scanning_sp.id
+        id                        = azuread_service_principal.sysdig_vm_workload_scanning_sp.object_id
         app_display_name          = azuread_service_principal.sysdig_vm_workload_scanning_sp.display_name
         app_id                    = azuread_service_principal.sysdig_vm_workload_scanning_sp.client_id
         app_owner_organization_id = azuread_service_principal.sysdig_vm_workload_scanning_sp.application_tenant_id


### PR DESCRIPTION
`azuread_service_principal.id` is now returning values of the form `/servicePrincipals/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Switch to the `azuread_service_principal.object_id` property which contains the same UUID without the prefix