### PR TITLE
feat(event-hub): add validation permissions (SSPROD-45861)

### DIFF
--- a/modules/integrations/event-hub/main.tf
+++ b/modules/integrations/event-hub/main.tf
@@ -129,7 +129,7 @@ resource "azurerm_role_assignment" "sysdig_subscription_reader" {
 #---------------------------------------------------------------------------------------------
 # Assign "Monitoring Reader" role to Sysdig SP at subscription level to check resource health
 #---------------------------------------------------------------------------------------------
-resource "azurerm_role_assignment" "sysdig_subscription_reader" {
+resource "azurerm_role_assignment" "sysdig_subscription_monitoring_reader" {
   scope                = data.azurerm_subscription.sysdig_subscription.id
   role_definition_name = "Monitoring Reader"
   principal_id         = azuread_service_principal.sysdig_event_hub_sp.object_id

--- a/modules/integrations/event-hub/main.tf
+++ b/modules/integrations/event-hub/main.tf
@@ -118,11 +118,11 @@ resource "azurerm_role_assignment" "sysdig_data_receiver" {
 }
 
 #---------------------------------------------------------------------------------------------
-# Assign "Monitoring Reader" role to Sysdig SP for reading Event Hub metrics for validation
+# Assign "Reader" role to Sysdig SP at subscription level to check resource existence
 #---------------------------------------------------------------------------------------------
-resource "azurerm_role_assignment" "sysdig_metrics_reader" {
-  scope                = azurerm_eventhub_namespace.sysdig_event_hub_namespace.id
-  role_definition_name = "Monitoring Reader"
+resource "azurerm_role_assignment" "sysdig_subscription_reader" {
+  scope                = data.azurerm_subscription.sysdig_subscription.id
+  role_definition_name = "Reader"
   principal_id         = azuread_service_principal.sysdig_event_hub_sp.object_id
 }
 

--- a/modules/integrations/event-hub/main.tf
+++ b/modules/integrations/event-hub/main.tf
@@ -127,6 +127,15 @@ resource "azurerm_role_assignment" "sysdig_subscription_reader" {
 }
 
 #---------------------------------------------------------------------------------------------
+# Assign "Monitoring Reader" role to Sysdig SP at subscription level to check resource health
+#---------------------------------------------------------------------------------------------
+resource "azurerm_role_assignment" "sysdig_subscription_reader" {
+  scope                = data.azurerm_subscription.sysdig_subscription.id
+  role_definition_name = "Monitoring Reader"
+  principal_id         = azuread_service_principal.sysdig_event_hub_sp.object_id
+}
+
+#---------------------------------------------------------------------------------------------
 # Create diagnostic settings for the subscription
 #---------------------------------------------------------------------------------------------
 resource "azurerm_monitor_diagnostic_setting" "sysdig_diagnostic_setting" {

--- a/modules/integrations/event-hub/main.tf
+++ b/modules/integrations/event-hub/main.tf
@@ -118,6 +118,15 @@ resource "azurerm_role_assignment" "sysdig_data_receiver" {
 }
 
 #---------------------------------------------------------------------------------------------
+# Assign "Monitoring Reader" role to Sysdig SP for reading Event Hub metrics for validation
+#---------------------------------------------------------------------------------------------
+resource "azurerm_role_assignment" "sysdig_metrics_reader" {
+  scope                = azurerm_eventhub_namespace.sysdig_event_hub_namespace.id
+  role_definition_name = "Monitoring Reader"
+  principal_id         = azuread_service_principal.sysdig_event_hub_sp.object_id
+}
+
+#---------------------------------------------------------------------------------------------
 # Create diagnostic settings for the subscription
 #---------------------------------------------------------------------------------------------
 resource "azurerm_monitor_diagnostic_setting" "sysdig_diagnostic_setting" {


### PR DESCRIPTION
This pull request includes changes to the `modules/integrations/event-hub/main.tf` file to enhance the role assignments for the Sysdig service principal. The most important changes include assigning additional roles at the subscription level to ensure the Sysdig service principal can check resource existence and health.

Enhancements to role assignments:

* Added a new resource `azurerm_role_assignment` for the "Reader" role to allow the Sysdig service principal to check resource existence at the subscription level.
* Added another resource `azurerm_role_assignment` for the "Monitoring Reader" role to enable the Sysdig service principal to check resource health at the subscription level.